### PR TITLE
OUTPUT plugins now manage their own thread pool. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![N|Solid](https://www.riodb.org/images/Logo_Name_Small.jpg)](https://www.riodb.org/index.html)
+[![N|Solid](https://www.riodb.org/images/logo_s.jpg)](https://www.riodb.org/index.html)
 
 RioDB (www.riodb.org) is a downloadable software for data stream processing.  
 You can build powerful data screening bots through simple SQL-like statements.

--- a/examples/bench/src/org/riodb/plugin/BENCH.java
+++ b/examples/bench/src/org/riodb/plugin/BENCH.java
@@ -41,6 +41,8 @@ under the License.
 package org.riodb.plugin;
 
 import java.time.Instant;
+import java.util.Base64;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jctools.queues.SpscChunkedArrayQueue;
@@ -174,7 +176,8 @@ public class BENCH implements RioDBPlugin, Runnable {
 
 		String stringsParam = getParameter(params, "strings");
 		if (stringsParam != null) {
-			strings = stringsParam.replace("'", "").split("\\|");
+			stringsParam = stringsParam.replace("'", "");
+			strings = stringsParam.split("\\|");
 		}
 
 		String incrementParam = getParameter(params, "increment");
@@ -299,5 +302,17 @@ public class BENCH implements RioDBPlugin, Runnable {
 	@Override
 	public String version() {
 		return VERSION;
+	}
+	
+	// function to decode base64
+	private final String decodeText(String s) {
+
+		try {
+			byte[] decodedBytes = Base64.getDecoder().decode(s.replace("$", "="));
+			return new String(decodedBytes);
+		} catch (IllegalArgumentException iae) {
+			// if s is invalid Base64, return original s
+			return s;
+		}
 	}
 }

--- a/examples/http/src/org/riodb/plugin/HTTP.java
+++ b/examples/http/src/org/riodb/plugin/HTTP.java
@@ -66,24 +66,27 @@ public class HTTP implements RioDBPlugin {
 	public void start() throws RioDBPluginException {
 		if(isInput) {
 			input.start();
+		} else {
+			output.start();
 		}
-		output.start();
 	}
 
 	@Override
 	public RioDBPluginStatus status() {
 		if(isInput) {
 			return input.status();
+		} else {
+			return output.status();
 		}
-		return output.status();
 	}
 
 	@Override
 	public void stop() throws RioDBPluginException {
 		if(isInput) {
 			input.stop();
+		} else {
+			output.stop();
 		}
-		output.stop();
 	}
 	
 	

--- a/examples/tcp/src/org/riodb/plugin/TCP.java
+++ b/examples/tcp/src/org/riodb/plugin/TCP.java
@@ -60,37 +60,51 @@ public class TCP implements RioDBPlugin {
 	private boolean isInput = true;
 
 	@Override
+	public int getQueueSize() {
+		if(isInput) {
+			return input.getQueueSize();
+		}
+		return output.getQueueSize();
+	}
+	
+	@Override
 	public String getType() {
 		return PLUGIN_NAME;
 	}
 
 	@Override
-	public String version() {
-		return VERSION;
-	}
-	
-	@Override
 	public void start() throws RioDBPluginException {
 		if(isInput) {
 			input.start();
+		} else {
+			output.start();
 		}
-		output.start();
+	}
+
+	@Override
+	public RioDBPluginStatus status() {
+		if(isInput) {
+			return input.status();
+		} else {
+			return output.status();
+		}
 	}
 
 	@Override
 	public void stop() {
 		if(isInput) {
 			input.stop();
+		} else {
+			output.stop();
 		}
-		output.stop();
 	}
+	
 	@Override
-	public RioDBPluginStatus status() {
-		if(isInput) {
-			return input.status();
-		}
-		return output.status();
+	public String version() {
+		return VERSION;
 	}
+	
+
 	
 	/*
  	*   Methods for INPUT usage
@@ -101,13 +115,6 @@ public class TCP implements RioDBPlugin {
 		return input.getNextInputMessage();
 	}
 
-	@Override
-	public int getQueueSize() {
-		if(isInput) {
-			return input.getQueueSize();
-		}
-		return 0;
-	}
 
 	@Override
 	public void initInput(String inputParams, RioDBStreamMessageDef def) throws RioDBPluginException {
@@ -115,8 +122,6 @@ public class TCP implements RioDBPlugin {
 
 		// throw new RioDBPluginException("TCP plugin does not support input methods.");
 	}
-
-	
 	
 
 	/*

--- a/examples/tcp/src/org/riodb/plugin/TcpOutput.java
+++ b/examples/tcp/src/org/riodb/plugin/TcpOutput.java
@@ -38,21 +38,107 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.net.Socket;
 import java.net.UnknownHostException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class TcpOutput {
-	
-	
+
+	// queue limits
+	public static final int QUEUE_INIT_CAPACITY = 244; // 10000;
+	public static final int MAX_CAPACITY = 1000000;
+
+	// logger
 	private Logger logger = LogManager.getLogger(TCP.class.getName());
 
 	private int status = 0; // 0 idle; 1 started; 2 warning; 3 fatal
-	
+
 	private String address = null;
 	private int portNumber;
 	private String delimiter = ",";
-	
+
+	// An Outgoing queue based on blockingQueue for efficient processing
+	private LinkedBlockingQueue<String[]> streamBlockingQueue;
+
+	// number of worker threads to send output in parallel
+	private int workers = 1;
+	private ExecutorService workerPool;
+
+	// boolean variable for interrupting thread while() loop.
+	private boolean interrupt;
+
+	// if an error occurs (like invalid number)
+	// we only log it once.
+	private boolean errorAlreadyCaught = false;
+
+	// Inner class for output workers
+
+	private static final String getParameter(String params[], String key) {
+		for (int i = 0; i < params.length; i++) {
+			if (key.equals(params[i].toLowerCase()) && i < params.length - 1) {
+				return params[i + 1];
+			}
+		}
+		return null;
+	}
+
+	private static final boolean isNumber(String s) {
+		if (s == null)
+			return false;
+		try {
+			Float.valueOf(s);
+			return true;
+		} catch (NumberFormatException nfe) {
+			return false;
+		}
+	}
+
+	// Method that child thread calls to dequeue messages from the queue
+	private void dequeAndSend() {
+
+		logger.debug(TCP.PLUGIN_NAME + " Output Worker Thread [" + Thread.currentThread().getName() + "] - started.");
+
+		while (!interrupt) {
+
+			String columns[];
+
+			// a quick poll in case queue is not empty
+			columns = streamBlockingQueue.poll();
+
+			// if queue was empty
+			if (columns == null || columns.length == 0) {
+
+				/// then we take() and wait for something to be received.
+				try {
+					columns = streamBlockingQueue.take();
+				} catch (InterruptedException e) {
+					logger.debug(TCP.PLUGIN_NAME + " Output WorkerThread [" + Thread.currentThread().getName()
+							+ "] -interrupted.");
+					break;
+				}
+			}
+
+			if (columns != null && columns.length > 0) {
+				sendTCPmsg(columns);
+			}
+		}
+
+		logger.debug(TCP.PLUGIN_NAME + " Output Worker Thread [" + Thread.currentThread().getName() + "] -stopped.");
+
+		status = 0;
+
+	}
+
+	// get queue size
+	public int getQueueSize() {
+
+		return streamBlockingQueue.size();
+
+	}
+
 	public void init(String outputParams, String[] columnHeaders) throws RioDBPluginException {
 
 		logger.debug("initializing TCP plugin for OUTPUT with paramters ( " + outputParams + ") ");
@@ -79,81 +165,117 @@ public class TcpOutput {
 		}
 
 		this.address = addressParam;
-		
-	}
 
-	public void sendOutput(String[] columns) {
-		
-		   String msg = "";
-
-			for (int i = 0; i < columns.length; i++) {
-				if (i > 0) {
-					msg = msg + delimiter;
-				}
-				msg = msg + columns[i];
+		int maxCapacity = MAX_CAPACITY;
+		// get optional queue capacity
+		String newMaxCapacity = getParameter(params, "queue_capacity");
+		if (newMaxCapacity != null) {
+			if (isNumber(newMaxCapacity) && Integer.valueOf(newMaxCapacity) > 0) {
+				maxCapacity = Integer.valueOf(newMaxCapacity);
+			} else {
+				status = 3;
+				throw new RioDBPluginException(
+						TCP.PLUGIN_NAME + " output requires positive intenger for 'max_capacity' parameter.");
 			}
-			
-			try (Socket socket = new Socket(address, portNumber)) {
-	   		 
-	            OutputStream output = socket.getOutputStream();
-	            PrintWriter writer = new PrintWriter(output, true);
-	            writer.println(msg);
-	            output.flush();
-	            output.close();
-	            socket.close();
 
-	        } catch (UnknownHostException e) {
-	 
-	        	if (status == 0) {
-					logger.error("TCP OUTPUT UnknownHostException");
-					logger.debug(e.getMessage().replace("\n", " ").replace("\r", " ").replace("\"", " "));
-				}
-				status = 2;
-	 
-	        } catch (IOException e) {
-	 
-	        	if (status == 0) {
-					logger.error("TCP OUTPUT IOException");
-					logger.debug(e.getMessage().replace("\n", " ").replace("\r", " ").replace("\"", " "));
-				}
-				status = 2;
-	        }
-    	
+		}
+
+		// if user opted for extreme mode...
+		String newWorkers = getParameter(params, "workers");
+		if (newWorkers != null) {
+			if (isNumber(newWorkers) && Integer.valueOf(newWorkers) > 0) {
+				workers = Integer.valueOf(newWorkers);
+			} else {
+				status = 3;
+				throw new RioDBPluginException(
+						TCP.PLUGIN_NAME + " output requires positive intenger for 'workers' parameter.");
+			}
+		}
+
+		streamBlockingQueue = new LinkedBlockingQueue<String[]>(maxCapacity);
+
 	}
 
-	
+	// method for sending columns to output worker(s)
+	public void sendOutput(String[] columns) {
+
+		streamBlockingQueue.offer(columns);
+
+	}
+
+	// procedure for sending UDP packet to socket.
+	private void sendTCPmsg(String columns[]) {
+
+		String msg = "";
+
+		for (int i = 0; i < columns.length; i++) {
+			if (i > 0) {
+				msg = msg + delimiter;
+			}
+			msg = msg + columns[i];
+		}
+
+		try (Socket socket = new Socket(address, portNumber)) {
+
+			OutputStream output = socket.getOutputStream();
+			PrintWriter writer = new PrintWriter(output, true);
+			writer.println(msg);
+			output.flush();
+			output.close();
+			socket.close();
+
+		} catch (UnknownHostException e) {
+
+			if (!errorAlreadyCaught) {
+				errorAlreadyCaught = true;
+				logger.error(
+						"TCP Output Worker Thread [" + Thread.currentThread().getName() + "]  UnknownHostException");
+				logger.debug(e.getMessage().replace("\n", " ").replace("\r", " ").replace("\"", " "));
+			}
+			status = 2;
+
+		} catch (IOException e) {
+
+			if (!errorAlreadyCaught) {
+				errorAlreadyCaught = true;
+				logger.error("TCP Output Worker Thread [" + Thread.currentThread().getName() + "] - IOException");
+				logger.debug(e.getMessage().replace("\n", " ").replace("\r", " ").replace("\"", " "));
+			}
+			status = 2;
+		}
+
+	}
+
 	public void start() {
+
+		errorAlreadyCaught = false;
+
+		logger.debug("TCP Output Worker starting...");
+		interrupt = false;
+		workerPool = Executors.newFixedThreadPool(workers);
+		Runnable task = () -> {
+			dequeAndSend();
+		};
+		for (int i = 0; i < workers; i++) {
+			workerPool.execute(task);
+		}
+
 		status = 1;
 	}
 
 	public RioDBPluginStatus status() {
 		return new RioDBPluginStatus(status);
 	}
-	
+
 	public void stop() {
+		logger.debug("TCP Output Worker stopping...");
+		interrupt = true;
+		try {
+			Thread.sleep(10);
+		} catch (InterruptedException e) {
+		}
+		workerPool.shutdown();
 		status = 0;
 	}
 
-	private static final String getParameter(String params[], String key) {
-		for (int i = 0; i < params.length; i++) {
-			if (key.equals(params[i].toLowerCase()) && i < params.length - 1) {
-				return params[i + 1];
-			}
-		}
-		return null;
-	}
-
-	private static final boolean isNumber(String s) {
-		if (s == null)
-			return false;
-		try {
-			Float.valueOf(s);
-			return true;
-		} catch (NumberFormatException nfe) {
-			return false;
-		}
-	}
-	
-	
-	
 }

--- a/examples/udp/src/org/riodb/plugin/UDP.java
+++ b/examples/udp/src/org/riodb/plugin/UDP.java
@@ -73,8 +73,9 @@ public class UDP implements RioDBPlugin {
 	public void start() throws RioDBPluginException {
 		if (isInput) {
 			input.start();
+		} else {
+			output.start();
 		}
-		output.start();
 	}
 
 	@Override
@@ -89,9 +90,19 @@ public class UDP implements RioDBPlugin {
 	public void stop() throws RioDBPluginException {
 		if (isInput) {
 			input.stop();
+		} else {
+			output.stop();
 		}
-		output.stop();
 	}
+
+	@Override
+	public int getQueueSize() {
+		if(isInput) {
+			return input.getQueueSize();
+		}
+		return output.getQueueSize();
+	}
+
 
 	/*
 	 * Methods for INPUT usage
@@ -102,15 +113,7 @@ public class UDP implements RioDBPlugin {
 		return input.getNextInputMessage();
 	}
 
-	@Override
-	public int getQueueSize() {
-		if(isInput) {
-			return input.getQueueSize();
-		}
-		return 0;
-	}
-
-	@Override
+		@Override
 	public void initInput(String inputParams, RioDBStreamMessageDef def) throws RioDBPluginException {
 		input.initInput(inputParams, def);
 	}

--- a/examples/udp/src/org/riodb/plugin/UdpOutput.java
+++ b/examples/udp/src/org/riodb/plugin/UdpOutput.java
@@ -47,27 +47,92 @@ import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.util.concurrent.LinkedBlockingQueue;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jctools.queues.SpscChunkedArrayQueue;
 
-public class UdpOutput {
+public class UdpOutput implements Runnable {
 
+	// queue limits
+	public static final int QUEUE_INIT_CAPACITY = 244; // 10000;
+	public static final int MAX_CAPACITY = 1000000;
+
+	// logger
 	private Logger logger = LogManager.getLogger(UDP.class.getName());
 
 	private int status = 0; // 0 idle; 1 started; 2 warning; 3 fatal
 
+	// running in mode EFFICIENT vs EXTREME
+	private boolean extremeMode = false;
+
+	// An Outgoing queue based on arrayQueue for extreme loads
+	private SpscChunkedArrayQueue<String[]> streamArrayQueue;
+
+	// An Outgoing queue based on blockingQueue for efficient processing
+	private LinkedBlockingQueue<String[]> streamBlockingQueue;
+
+	// Thread for running worker
+	private Thread socketWorkerThread;
+
+	// boolean variable for interrupting thread while() loop.
+	private boolean interrupt;
+
+	// if an error occurs (like invalid number)
+	// we only log it once.
+	private boolean errorAlreadyCaught = false;
+
+	// socket details for sending UDP message
 	private DatagramSocket socket;
 	private InetAddress address;
 	private int portNumber;
 
+	// delimiter used to separate columns in output.
 	private String delimiter = ",";
-	
+
+	// local function to get parameter values from initializing string
+	// (The init string is the text in parenthesis in the SELECT .. OUTPUT
+	// statement.
+	private static final String getParameter(String params[], String key) {
+		for (int i = 0; i < params.length; i++) {
+			if (key.equals(params[i].toLowerCase()) && i < params.length - 1) {
+				return params[i + 1];
+			}
+		}
+		return null;
+	}
+
+	// local function to determine if a string is a number
+	private static final boolean isNumber(String s) {
+		if (s == null)
+			return false;
+		try {
+			Float.valueOf(s);
+			return true;
+		} catch (NumberFormatException nfe) {
+			return false;
+		}
+	}
+
+	// get queue size
+	public int getQueueSize() {
+		if (extremeMode) {
+			return streamBlockingQueue.size();
+		}
+		return streamArrayQueue.size();
+	}
+
+	// initialize plugin for use as OUTPUT
 	public void initOutput(String outputParams, String[] columnHeaders) throws RioDBPluginException {
 
 		logger.debug("initializing UDP plugin for OUTPUT with paramters ( " + outputParams + ") ");
 
+		// output parameters are provided by user in SQL statement (everything between
+		// parenthesis)
 		String params[] = outputParams.split(" ");
 
+		// output destination
 		String addressParam = getParameter(params, "address");
 		String portParam = getParameter(params, "port");
 
@@ -82,9 +147,33 @@ public class UdpOutput {
 		}
 		this.portNumber = Integer.valueOf(portParam);
 
+		// field delimiter
 		String delimiterParam = getParameter(params, "delimiter");
 		if (delimiterParam != null) {
 			delimiter = delimiterParam.replace("'", "");
+		}
+
+		int maxCapacity = MAX_CAPACITY;
+		// get optional queue capacity
+		String newMaxCapacity = getParameter(params, "queue_capacity");
+		if (newMaxCapacity != null) {
+			if (isNumber(newMaxCapacity) && Integer.valueOf(newMaxCapacity) > 0) {
+				maxCapacity = Integer.valueOf(newMaxCapacity);
+			} else {
+				status = 3;
+				throw new RioDBPluginException(
+						UDP.PLUGIN_NAME + " output requires positive intenger for 'max_capacity' parameter.");
+			}
+
+		}
+
+		// if user opted for extreme mode...
+		String mode = getParameter(params, "mode");
+		if (mode != null && mode.equals("extreme")) {
+			extremeMode = true;
+			streamArrayQueue = new SpscChunkedArrayQueue<String[]>(QUEUE_INIT_CAPACITY, maxCapacity);
+		} else {
+			streamBlockingQueue = new LinkedBlockingQueue<String[]>(maxCapacity);
 		}
 
 		try {
@@ -96,9 +185,11 @@ public class UdpOutput {
 
 	}
 
-	public void sendOutput(String[] columns) {
+	private DatagramPacket makeDatagramPacket(String[] columns) {
+
 		String outStr = "";
 
+		// concatenate fields split by delimiter.
 		for (int i = 0; i < columns.length; i++) {
 			if (i > 0) {
 				outStr = outStr + delimiter;
@@ -106,57 +197,141 @@ public class UdpOutput {
 			outStr = outStr + columns[i];
 		}
 
+		// prepare data for sucket.
 		byte[] buf = outStr.getBytes();
-		DatagramPacket packet = new DatagramPacket(buf, buf.length, address, portNumber);
-		try {
-			socket.send(packet);
-		} catch (IOException e) {
-			if (status == 0) {
-				logger.error("UDP OUTPUT IOException.");
-				logger.debug(e.getMessage().replace("\n", " ").replace("\r", " ").replace("\"", " "));
-			}
-			status = 2;
-		}
+		return new DatagramPacket(buf, buf.length, address, portNumber);
 
 	}
 
-	public void start() throws RioDBPluginException {
-		try {
-			this.socket = new DatagramSocket();
-		} catch (SocketException e) {
-			status = 3;
-			throw new RioDBPluginException("UDP OUTPUT: SocketException while starting plugin");
+	// Runnable run() method
+	// Thread dequeues packets ready to be sent to destination
+	@Override
+	public void run() {
+		logger.debug(UDP.PLUGIN_NAME + " output worker started.");
+
+		// again, extremeMode works with arrayDeque,
+		// and efficient mode works with blockingQueue
+
+		while (!interrupt) {
+
+			String columns[];
+
+			// if running extreme mode.
+			if (extremeMode) {
+
+				// we poll the arraydequeue. Could be empty.
+				columns = streamArrayQueue.poll();
+				// if empty, we do a wait 1ms and try again.
+				while ((columns == null || columns.length == 0) && !interrupt) {
+					// wait and try again until not null
+					try {
+						Thread.sleep(1);
+					} catch (InterruptedException e) {
+						;
+					}
+					columns = streamArrayQueue.poll();
+				}
+
+			} else { // efficient mode.
+
+				// a quick poll in case queue is not empty
+				columns = streamBlockingQueue.poll();
+
+				// if queue was empty
+				if (columns == null || columns.length == 0) {
+
+					/// then we take() and wait for something to be received.
+					try {
+						columns = streamBlockingQueue.take();
+					} catch (InterruptedException e) {
+						logger.debug(UDP.PLUGIN_NAME + " OUTPUT queue interrupted.");
+						break;
+					}
+				}
+			}
+
+			if (columns != null && columns.length > 0) {
+				DatagramPacket packet = makeDatagramPacket(columns);
+				sendUDPpacket(packet);
+			}
 		}
+
+		logger.debug(UDP.PLUGIN_NAME + " output worker stopped.");
+
 		status = 0;
 	}
 
+	// procedure to send UDP output to destination.
+	public void sendOutput(String[] columns) {
+
+		// send to appropriate queue.
+		if (extremeMode) {
+			streamArrayQueue.offer(columns);
+		} else {
+			streamBlockingQueue.offer(columns);
+		}
+
+	}
+
+	// procedure for sending UDP packet to socket.
+	private void sendUDPpacket(DatagramPacket packet) {
+		try {
+			socket.send(packet);
+		} catch (IOException e) {
+			if (!errorAlreadyCaught) {
+				logger.error("UDP OUTPUT IOException.");
+				logger.debug(e.getMessage().replace("\n", " ").replace("\r", " ").replace("\"", " "));
+			}
+			status = 1;
+		}
+	}
+
+	// procedure for starting the output plugin thread.
+	public void start() throws RioDBPluginException {
+		interrupt = false;
+		try {
+			this.socket = new DatagramSocket();
+			socketWorkerThread = new Thread(this);
+			socketWorkerThread.setName(this.getClass().getName());
+			socketWorkerThread.start();
+		} catch (SocketException e) {
+			status = 3;
+			RioDBPluginException p = new RioDBPluginException("Failed to start output worker. " + e.getMessage());
+			p.setStackTrace(e.getStackTrace());
+			throw p;
+		}
+		status = 2;
+		logger.debug("UDP Output " + portNumber + " started.");
+
+	}
+
+	// getter for plugin status
 	public RioDBPluginStatus status() {
 		return new RioDBPluginStatus(status);
 	}
 
+	// procedure for stopping output plugin thread.
 	public void stop() {
-		if (!socket.isClosed()) {
-			socket.close();
-		}
-	}
+		logger.debug("UDP Output closing socket " + portNumber);
 
-	private static final String getParameter(String params[], String key) {
-		for (int i = 0; i < params.length; i++) {
-			if (key.equals(params[i].toLowerCase()) && i < params.length - 1) {
-				return params[i + 1];
-			}
-		}
-		return null;
-	}
-
-	private static final boolean isNumber(String s) {
-		if (s == null)
-			return false;
+		interrupt = true;
 		try {
-			Float.valueOf(s);
-			return true;
-		} catch (NumberFormatException nfe) {
-			return false;
+			if (!socket.isClosed()) {
+				socket.close();
+			}
+			Thread.sleep(10);
+		} catch (InterruptedException e) {
+			;
 		}
+		logger.debug("UDP Output interrupting Thread.");
+		// socket.close();
+		// socketListenerThread.interrupt();
+		try {
+			Thread.sleep(10);
+		} catch (InterruptedException e) {
+			;
+		}
+		status = 0;
+
 	}
 }


### PR DESCRIPTION
RioDB no longer manages threadpool (ExecutorService) for output plugins.   
This is not a responsibility of the output plugin.   
As such, updated UDP, TCP and HTTP plugins to kick off their own threads.   